### PR TITLE
Fixes for ListMarkerSpaceRule and BlanksAroundListsRule when list empty

### DIFF
--- a/markdown/src/main/kotlin/com/appmattus/markdown/rules/BlanksAroundListsRule.kt
+++ b/markdown/src/main/kotlin/com/appmattus/markdown/rules/BlanksAroundListsRule.kt
@@ -49,7 +49,7 @@ class BlanksAroundListsRule(
 ) : Rule() {
 
     private val fenceRegEx = Regex("^(`{3,}|~{3,})")
-    private val listRegEx = Regex("^([*+\\-]|(\\d+\\.))\\s")
+    private val listRegEx = Regex("^([*+\\-]|(\\d+\\.))(\\s|$)")
     private val emptyRegEx = Regex("^(\\s|$)")
 
     override fun visitDocument(document: MarkdownDocument, errorReporter: ErrorReporter) {

--- a/markdown/src/main/kotlin/com/appmattus/markdown/rules/ListMarkerSpaceRule.kt
+++ b/markdown/src/main/kotlin/com/appmattus/markdown/rules/ListMarkerSpaceRule.kt
@@ -88,9 +88,9 @@ class ListMarkerSpaceRule(
                 item as ListItem
 
                 // For task lists we look at the marker suffix as the opening content
-                val startContent = item.markerSuffix.takeIf(CharSequence::isNotEmpty) ?: item.firstChild.chars
+                val startContent = item.markerSuffix.takeIf(CharSequence::isNotEmpty) ?: item.firstChild?.chars
 
-                if (startContent.startOffset - item.openingMarker.endOffset != indent) {
+                if (startContent != null && startContent.startOffset - item.openingMarker.endOffset != indent) {
                     val description = "Ensure $indent spaces after list marker. Configuration: ulSingle=$ulSingle, " +
                             "olSingle=$olSingle, ulMulti=$ulMulti, olMulti=$olMulti."
 

--- a/markdown/src/test/kotlin/com/appmattus/markdown/rules/Files.kt
+++ b/markdown/src/test/kotlin/com/appmattus/markdown/rules/Files.kt
@@ -20,6 +20,7 @@ val allFiles = listOf(
     "consistent_bullet_styles_plus.md",
     "emphasis_instead_of_headers.md",
     "empty_doc.md",
+    "empty-list.md",
     "fenced_code_blocks.md",
     "fenced_code_with_nesting.md",
     "fenced_code_without_blank_lines.md",

--- a/markdown/src/test/resources/empty-list.md
+++ b/markdown/src/test/resources/empty-list.md
@@ -1,0 +1,5 @@
+# Empty list item caused exception in ListMarkerSpaceRule
+
+1. Foo
+1.
+1. Bar


### PR DESCRIPTION
ListMarkerSpaceRule was throwing a NullPointerException when list item is empty.

BlanksAroundListsRule was triggering when list item is empty as it trims all whitespace so would no longer match the entry as a list item.