### PR TITLE
Configure the check task lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Run the plugin with:
 or by adding a dependency to the task:
 
 ```kotlin
-tasks.getByName("check")
-    .finalizedBy(rootProject.tasks.getByName("markdownlint"))
+tasks.named("check") {
+  dependsOn(tasks.named("markdownlint"))
+}
 ```
 
 To customise the rules and report generation specify the configuration in


### PR DESCRIPTION
The previous build script would create the task greedily, see https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
Furthermore, using finalizedBy implies that the markdownlint in some sense will finalize the check task, e.g. by closing some shared resource.